### PR TITLE
Add documentation to isStatusMsg

### DIFF
--- a/src/common/network.h
+++ b/src/common/network.h
@@ -131,6 +131,17 @@ public :
     inline bool isMe(IrcUser *ircuser) const { return (ircuser->nick().toLower() == myNick().toLower()); }
 
     bool isChannelName(const QString &channelname) const;
+
+    /**
+     * Checks if the target counts as a STATUSMSG
+     *
+     * Status messages are prefixed with one or more characters from the server-provided STATUSMSG
+     * if available, otherwise "@" and "+" are assumed.  Generally, status messages sent to a
+     * channel are only visible to those with the same or higher permissions, e.g. voiced.
+     *
+     * @param[in] target Name of destination, e.g. a channel or query
+     * @returns True if a STATUSMSG, otherwise false
+     */
     bool isStatusMsg(const QString &target) const;
 
     inline bool isConnected() const { return _connected; }


### PR DESCRIPTION
Add Doxygen-style documentation to the `isStatusMsg` function in `network.h`.

_Feel free to squash the commit; it's fairly trivial._
